### PR TITLE
Add optional values support to the user consent url

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,50 +28,79 @@ See: https://developer.ebay.com/api-docs/static/oauth-tokens.html
 
 ## Installation
 
+Using npm:
 ```shell
 npm install ebay-oauth-nodejs-client
 ```
-or 
 
+Using yarn:
 ```shell
 yarn add ebay-oauth-nodejs-client
 ```
 
 ## Usage
 
+##### EbayAuthToken(config)
+Create a new instance of `EbayAuthToken` with a relevant config.
 ```js
 const EbayAuthToken = require('ebay-oauth-nodejs-client');
+
 const ebayAuthToken = new EbayAuthToken({
     clientId: '<your_client_id>',
     clientSecret: '<your_client_secret>',
     redirectUri: '<redirect uri>'
 });
-// generate client credential token
+```
+
+##### ebayAuthToken.getApplicationToken(environment)
+Generate client credential token.
+```js
 (async () => {
     const token = await ebayAuthToken.getApplicationToken('PRODUCTION');
     console.log(token);
 })();
+```
 
-// generate user consent authorization url.
-(async () => {
-    const authUrl = await ebayAuthToken.generateUserAuthorizationUrl('PRODUCTION', scopes);
+##### ebayAuthToken.generateUserAuthorizationUrl(environment, scopes[, options])
+Generate user consent authorization url.
+```js
+(() => {
+    const authUrl = ebayAuthToken.generateUserAuthorizationUrl('PRODUCTION', scopes);
     console.log(authUrl);
 })();
+```
 
-// Getting a User access token.
+You can also provide optional values:\
+**state:** An opaque value used by the client to maintain state between the request and callback.\
+**prompt:** Force a user to log in when you redirect them to the Grant Application Access page, even if they already have an existing user session.
 
+The method call above could also be done as
+```js
+(() => {
+    const options = { state: 'custom-state-value', prompt: 'login' };
+    const authUrl = ebayAuthToken.generateUserAuthorizationUrl('PRODUCTION', scopes, options);
+    console.log(authUrl);
+})();
+```
+
+##### ebayAuthToken.exchangeCodeForAccessToken(environment, code)
+Getting a User access token.
+```js
 (async () => {
     const accessToken = await ebayAuthToken.exchangeCodeForAccessToken('PRODUCTION', code);
     console.log(accessToken);
 })();
+```
 
-// Using a refresh token to update a User access token (Updating the expired access token).
+##### ebayAuthToken.getAccessToken(environment, refreshToken, scopes)
+Using a refresh token to update a User access token (Updating the expired access token).
+```js
 (async () => {
     const accessToken = await ebayAuthToken.getAccessToken('PRODUCTION', refreshToken, scopes);
     console.log(accessToken);
 })();
-
 ```
+
 ## Library Setup and getting started
 
 1. Invoke the oauth ebay library as given below
@@ -85,7 +114,8 @@ OR
 ```javascript
 const ebayAuthToken = new EbayAuthToken({
     clientId: '<your_client_id>',
-    clientSecret: '<your_client_secret>'
+    clientSecret: '<your_client_secret>',
+    redirectUri: '<redirect_uri_name>'
 });
 ```
 2. If you want to get your application credentials such as AppId, DevId, and CertId. Refer to [Creating eBay Developer Account](https://developer.ebay.com/api-docs/static/creating-edp-account.html) for details on how to get these credentials.

--- a/demo/example.js
+++ b/demo/example.js
@@ -40,7 +40,8 @@ let ebayAuthToken = new EbayAuthToken({
 // pass the credentials through constructor
 ebayAuthToken = new EbayAuthToken({
     clientId: '---Client id ----',
-    clientSecret: '-- client secret---'
+    clientSecret: '-- client secret---',
+    redirectUri: '-- redirect uri name --'
 });
 
 const clientScope = 'https://api.ebay.com/oauth/api_scope';
@@ -54,6 +55,9 @@ ebayAuthToken.getApplicationToken('PRODUCTION', clientScope).then((data) => {
 // // Authorization Code Auth Flow
 ebayAuthToken.generateUserAuthorizationUrl('PRODUCTION', scopes); // get user consent url.
 // Using user consent url, you will be able to generate the code which you can use it for exchangeCodeForAccessToken.
+// Also accepts optional values: prompt, state
+ebayAuthToken.generateUserAuthorizationUrl('PRODUCTION', scopes, { prompt: 'login', state: 'custom-state-value' });
+
 // // Exchange Code for Authorization token
 ebayAuthToken.exchangeCodeForAccessToken('PRODUCTION', code).then((data) => { // eslint-disable-line no-undef
     console.log(data);

--- a/src/index.js
+++ b/src/index.js
@@ -66,22 +66,26 @@ class EbayOauthToken {
 
     /**
      * generate user consent authorization url.
-     * @param environment Environment (production/sandbox).
-     * @param scopes array list of scopes for which you need to generate the access token.
-     * @param state custom state value.
+     * @param {string} environment Environment (production/sandbox).
+     * @param {string[]} scopes array list of scopes for which you need to generate the access token.
+     * @param {Object} options optional values
+     * @param {string} options.state custom state value
+     * @param {string} options.prompt enforce to log in
      * @return userConsentUrl
     */
-    generateUserAuthorizationUrl(environment, scopes, state) {
+    generateUserAuthorizationUrl(environment, scopes, options) {
         validateParams(environment, scopes, this.credentials);
         const credentials = this.credentials[environment];
         if (!credentials) throw new Error('Error while reading the credentials, Kindly check here to configure');
         if (!credentials.redirectUri) throw new Error('redirect_uri is required for redirection after sign in \n kindly check here https://developer.ebay.com/api-docs/static/oauth-redirect-uri.html');
+        if (options && typeof(options) !== 'object') throw new Error('Improper way to provide optional values');
         this.scope = Array.isArray(scopes) ? scopes.join('%20') : scopes;
+        const { prompt, state } = options || {};
         let queryParam = `client_id=${credentials.clientId}`;
         queryParam = `${queryParam}&redirect_uri=${credentials.redirectUri}`;
         queryParam = `${queryParam}&response_type=code`;
         queryParam = `${queryParam}&scope=${this.scope}`;
-        queryParam = `${queryParam}&prompt=${this.prompt}`;
+        queryParam = prompt ? `${queryParam}&prompt=${prompt}` : queryParam;
         queryParam = state ? `${queryParam}&state=${state}` : queryParam;
         const baseUrl = environment === 'PRODUCTION' ? consts.OAUTHENVIRONMENT_WEBENDPOINT_PRODUCTION
             : consts.OAUTHENVIRONMENT_WEBENDPOINT_SANDBOX; // eslint-disable-line 

--- a/test/test.js
+++ b/test/test.js
@@ -63,20 +63,31 @@ describe('test EbayAuthToken', () => {
         }).to.throw(Error, 'Error while reading the credentials, Kindly check here to configure');
     });
 
-    it('test generateUserAuthorizationUrl without prompt', () => {
+    it('test generateUserAuthorizationUrl without options', () => {
         const ebayAuthToken = new EbayAuthToken({
             filePath: 'test/test.json'
         });
         const scope = 'https://api.ebay.com/oauth/api_scope';
-        expect(ebayAuthToken.generateUserAuthorizationUrl('PRODUCTION', scope)).to.equal('https://auth.ebay.com/oauth2/authorize?client_id=PROD1234ABCD&redirect_uri=PRODREDIRECT&response_type=code&scope=https://api.ebay.com/oauth/api_scope&prompt=undefined');
+        expect(ebayAuthToken.generateUserAuthorizationUrl('PRODUCTION', scope)).to.equal('https://auth.ebay.com/oauth2/authorize?client_id=PROD1234ABCD&redirect_uri=PRODREDIRECT&response_type=code&scope=https://api.ebay.com/oauth/api_scope');
     });
 
-    it('test generateUserAuthorizationUrl with state', () => {
+    it('test generateUserAuthorizationUrl with incorrect options', () => {
         const ebayAuthToken = new EbayAuthToken({
             filePath: 'test/test.json'
         });
         const scope = 'https://api.ebay.com/oauth/api_scope';
-        expect(ebayAuthToken.generateUserAuthorizationUrl('PRODUCTION', scope, 'state')).to.equal('https://auth.ebay.com/oauth2/authorize?client_id=PROD1234ABCD&redirect_uri=PRODREDIRECT&response_type=code&scope=https://api.ebay.com/oauth/api_scope&prompt=undefined&state=state');
+        expect(() => {
+            ebayAuthToken.generateUserAuthorizationUrl('PRODUCTION', scope, 'options');
+        }).to.throw(Error, 'Improper way to provide optional values');
+    });
+
+    it('test generateUserAuthorizationUrl with options', () => {
+        const ebayAuthToken = new EbayAuthToken({
+            filePath: 'test/test.json'
+        });
+        const scope = 'https://api.ebay.com/oauth/api_scope';
+        const options = { prompt: 'login', state: 'state' };
+        expect(ebayAuthToken.generateUserAuthorizationUrl('PRODUCTION', scope, options)).to.equal('https://auth.ebay.com/oauth2/authorize?client_id=PROD1234ABCD&redirect_uri=PRODREDIRECT&response_type=code&scope=https://api.ebay.com/oauth/api_scope&prompt=login&state=state');
     });
 
     it('test generateUserAuthorizationUrl with sandbox env', () => {
@@ -84,7 +95,7 @@ describe('test EbayAuthToken', () => {
             filePath: 'test/test.json'
         });
         const scope = 'https://api.ebay.com/oauth/api_scope';
-        expect(ebayAuthToken.generateUserAuthorizationUrl('SANDBOX', scope)).to.equal('https://auth.sandbox.ebay.com/oauth2/authorize?client_id=SAND1234ABCD&redirect_uri=SANDBOXREDIRECT&response_type=code&scope=https://api.ebay.com/oauth/api_scope&prompt=undefined');
+        expect(ebayAuthToken.generateUserAuthorizationUrl('SANDBOX', scope)).to.equal('https://auth.sandbox.ebay.com/oauth2/authorize?client_id=SAND1234ABCD&redirect_uri=SANDBOXREDIRECT&response_type=code&scope=https://api.ebay.com/oauth/api_scope');
     });
 
     it('test exchangeCodeForAccessToken without code', () => {


### PR DESCRIPTION
**Changes:**
- Improved the [generateUserAuthorizationUrl](https://github.com/eBay/ebay-oauth-nodejs-client/blob/a91205277693879e66e3c34e072b69ffefe1879c/src/index.js#L74) method definition to accept optional values (prompt, state).
- Wrote relevant tests.
- Updated the docs and example code respectively.